### PR TITLE
Fixes #1: BusFlagEncoder permits highway=pedestrian if psv/bus=yes

### DIFF
--- a/src/main/java/de/mfdz/osmrf/graphhopper/BusFlagEncoder.java
+++ b/src/main/java/de/mfdz/osmrf/graphhopper/BusFlagEncoder.java
@@ -25,10 +25,23 @@ public class BusFlagEncoder extends CarFlagEncoder
         intendedValues.add("designated");
         absoluteBarriers.remove("bus_trap");
         absoluteBarriers.remove("sump_buster");
+        defaultSpeedMap.put("pedestrian", 6);
     }
 
+    @Override
     protected boolean isOneway(ReaderWay way) {
         return !(way.hasTag("oneway:bus", "no") || way.hasTag("oneway:psv", "no")) && super.isOneway(way);
+    }
+
+    @Override
+    public EncodingManager.Access getAccess(ReaderWay way) {
+         String highwayValue = way.getTag("highway");
+         String firstValue = way.getFirstPriorityTag(this.restrictions);
+         if ("pedestrian".equals(highwayValue)) {
+             return intendedValues.contains(firstValue) ? EncodingManager.Access.WAY : EncodingManager.Access.CAN_SKIP;
+         } else {
+             return super.getAccess(way);
+         }
     }
 
     @Override

--- a/src/test/java/de/mfdz/osmrf/graphhopper/BusFlagEncoderTest.java
+++ b/src/test/java/de/mfdz/osmrf/graphhopper/BusFlagEncoderTest.java
@@ -39,5 +39,23 @@ public class BusFlagEncoderTest {
         assertTrue(accessEnc.getBool(true, flags));
         way.clearTags();
     }
+
+    @Test
+    public void testGetAccess_HighwayPedestrian() {
+        // e.g. w75077805
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "pedestrian");
+        way.setTag("psv", "yes");
+        EncodingManager.Access access = encoder.getAccess(way);
+        assertTrue("highway=predestrian with psv=yes should be accessible",access.isWay());
+        way.clearTags();
+
+        // without psv, pedestrian should not be accessible
+        way.setTag("highway", "pedestrian");
+        access = encoder.getAccess(way);
+        assertFalse("highway=predestrian without psv=yes should not be accessible", access.isWay());
+        way.clearTags();
+
+    }
 }
 


### PR DESCRIPTION
Adds pedestrian with a default speed of 6km/h, but only if first priority tag is in intendedValues.